### PR TITLE
Update bignum.h

### DIFF
--- a/src/bignum.h
+++ b/src/bignum.h
@@ -536,7 +536,7 @@ public:
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
         if (BN_is_negative(this))
 #else
-        if (BN_is_negative(bn))
+        if (BN_is_negative(bn1))
 #endif
             str += "-";
         reverse(str.begin(), str.end());


### PR DESCRIPTION
Perhaps a small oversight? bn1 is used in all other #else conditions, as apposed to bn, within ToString. It seems to me bn1 should be used in this #else also and not bn.