### PR TITLE
Revert "Update bignum.h"

### DIFF
--- a/src/bignum.h
+++ b/src/bignum.h
@@ -536,7 +536,7 @@ public:
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
         if (BN_is_negative(this))
 #else
-        if (BN_is_negative(bn1))
+        if (BN_is_negative(bn))
 #endif
             str += "-";
         reverse(str.begin(), str.end());


### PR DESCRIPTION
Reverts aurarad/Auroracoin#17

I had another look at the ToString function, to see what this PR actually would do and how this would relate to the original file. bn is set in the init function and is the original bn value, in the beginning of ToString this is copied to bn1 to allow calculations of the value and format the string value. The change determines if the original value (so bn, not the result of the calculations in bn1) is negative and adds a "-" to the result string.

Where there actual problems with this?