### PR TITLE
Add 'dnsseed.auroracoin.cc' to DNS Seeder / Node Trackers

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -172,6 +172,7 @@ public:
         vSeeds.emplace_back("electrum2.auroracoin.is");
         vSeeds.emplace_back("electrum3.auroracoin.is");
         vSeeds.emplace_back("electrum4.auroracoin.is");
+        vSeeds.emplace_back("dnsseed.auroracoin.cc");
 
 
 


### PR DESCRIPTION
##This patch adds "dnsseed.auroracoin.cc" to the DNS Seeders / NodeTrackers in chainparams.cpp

Current seeders seem to have an issue, as they only return 1 IP address , the same one always, (they should return many more) and because of this, it is likely that the nodes at those IP's are already at capacity and may not be accepting new connections. This is a problem for new nodes / wallets to connect and have a good experience quickly downloading the blockchain.

Using `dig` tool it is simple to verify this:

_dig dnsseed.auroracoin.cc A_

```
; <<>> DiG 9.16.1-Ubuntu <<>> dnsseed.auroracoin.cc A
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 57995
;; flags: qr rd ra; QUERY: 1, ANSWER: 7, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; QUESTION SECTION:
;dnsseed.auroracoin.cc.		IN	A

;; ANSWER SECTION:
dnsseed.auroracoin.cc.	3600	IN	A	62.171.189.219
dnsseed.auroracoin.cc.	3600	IN	A	85.15.179.171
dnsseed.auroracoin.cc.	3600	IN	A	80.65.23.139
dnsseed.auroracoin.cc.	3600	IN	A	65.109.141.173
dnsseed.auroracoin.cc.	3600	IN	A	157.161.128.56
dnsseed.auroracoin.cc.	3600	IN	A	87.98.244.13
dnsseed.auroracoin.cc.	3600	IN	A	86.123.62.127

;; Query time: 592 msec
;; SERVER: 8.8.8.8#53(8.8.8.8)
;; WHEN: Mon May 29 20:46:24 UTC 2023
;; MSG SIZE  rcvd: 162
```

Here, dnsseed.auroracoin.cc returns 7 ip's; 
a subsequent query also returns 7 ip's but some are different, as should be, to spread the load to all nodes in the network:

_dig dnsseed.auroracoin.cc A_

```
; <<>> DiG 9.16.1-Ubuntu <<>> dnsseed.auroracoin.cc A
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 40803
;; flags: qr rd ra; QUERY: 1, ANSWER: 7, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; QUESTION SECTION:
;dnsseed.auroracoin.cc.		IN	A

;; ANSWER SECTION:
dnsseed.auroracoin.cc.	3600	IN	A	5.188.104.245
dnsseed.auroracoin.cc.	3600	IN	A	65.109.141.173
dnsseed.auroracoin.cc.	3600	IN	A	91.206.16.214
dnsseed.auroracoin.cc.	3600	IN	A	87.98.244.13
dnsseed.auroracoin.cc.	3600	IN	A	147.135.191.162
dnsseed.auroracoin.cc.	3600	IN	A	161.97.137.213
dnsseed.auroracoin.cc.	3600	IN	A	198.27.82.41

;; Query time: 792 msec
;; SERVER: 8.8.8.8#53(8.8.8.8)
;; WHEN: Mon May 29 21:06:22 UTC 2023
;; MSG SIZE  rcvd: 162
```

For comparison, current DNS Seeders:
```
dig electrum1.auroracoin.is A | grep electrum1
; <<>> DiG 9.16.1-Ubuntu <<>> electrum1.auroracoin.is A
;electrum1.auroracoin.is.	IN	A
electrum1.auroracoin.is. 14400	IN	A	94.242.229.111
dig electrum1.auroracoin.is A | grep electrum1
; <<>> DiG 9.16.1-Ubuntu <<>> electrum1.auroracoin.is A
;electrum1.auroracoin.is.	IN	A
electrum1.auroracoin.is. 14398	IN	A	94.242.229.111
dig electrum1.auroracoin.is A | grep electrum1
; <<>> DiG 9.16.1-Ubuntu <<>> electrum1.auroracoin.is A
;electrum1.auroracoin.is.	IN	A
electrum1.auroracoin.is. 14400	IN	A	94.242.229.111
dig electrum1.auroracoin.is A | grep electrum1
; <<>> DiG 9.16.1-Ubuntu <<>> electrum1.auroracoin.is A
;electrum1.auroracoin.is.	IN	A
electrum1.auroracoin.is. 14400	IN	A	94.242.229.111
```

always resturns the same IP

same situation with number 2:

```
dig electrum2.auroracoin.is A | grep electrum2
; <<>> DiG 9.16.1-Ubuntu <<>> electrum2.auroracoin.is A
;electrum2.auroracoin.is.	IN	A
electrum2.auroracoin.is. 14400	IN	A	104.236.13.120
dig electrum2.auroracoin.is A | grep electrum2
; <<>> DiG 9.16.1-Ubuntu <<>> electrum2.auroracoin.is A
;electrum2.auroracoin.is.	IN	A
electrum2.auroracoin.is. 14400	IN	A	104.236.13.120
dig electrum2.auroracoin.is A | grep electrum2
; <<>> DiG 9.16.1-Ubuntu <<>> electrum2.auroracoin.is A
;electrum2.auroracoin.is.	IN	A
electrum2.auroracoin.is. 13850	IN	A	104.236.13.120
```

and number 3:
```
; <<>> DiG 9.16.1-Ubuntu <<>> electrum3.auroracoin.is A
;electrum3.auroracoin.is.	IN	A
electrum3.auroracoin.is. 14400	IN	A	178.62.202.79
dig electrum3.auroracoin.is A | grep electrum3
; <<>> DiG 9.16.1-Ubuntu <<>> electrum3.auroracoin.is A
;electrum3.auroracoin.is.	IN	A
electrum3.auroracoin.is. 14400	IN	A	178.62.202.79
```

and number 4 is the same issue:
```
dig electrum4.auroracoin.is A | grep electrum4
; <<>> DiG 9.16.1-Ubuntu <<>> electrum4.auroracoin.is A
;electrum4.auroracoin.is.	IN	A
electrum4.auroracoin.is. 14400	IN	A	178.62.5.211
dig electrum4.auroracoin.is A | grep electrum4
; <<>> DiG 9.16.1-Ubuntu <<>> electrum4.auroracoin.is A
;electrum4.auroracoin.is.	IN	A
electrum4.auroracoin.is. 14395	IN	A	178.62.5.211
```

Adding 'dnsseed.auroracoin.cc' will enhance the operation of the network and increase reliability.   Additionally, optimizing the setup of the current DNS seeders  ( electrum1,2,3, & 4 .auroracoin.is ) is important to properly support all the nodes / wallets that currently rely only on these seeders.  Please contact me for help with that issue.

DBKeys
dbkeys   "at" proton.me
or on communitycoins Telegram channel